### PR TITLE
Weaken content type check

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -25,7 +26,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// check for content-type and POST method.
 	if !s.options.DisableTransportChecks {
-		if r.Header.Get("Content-Type") != contentTypeJSON {
+		if !strings.HasPrefix(r.Header.Get("Content-Type"), contentTypeJSON) {
 			w.WriteHeader(http.StatusUnsupportedMediaType)
 			return
 		} else if r.Method == http.MethodGet {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -13,6 +13,40 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+func TestServer_ServeHTTPWithHeaders(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(rpc.ServeHTTP))
+	defer ts.Close()
+
+	var tc = []struct {
+		h string
+		s int
+	}{
+		{
+			h: "application/json",
+			s: 200,
+		},
+		{
+			h: "application/json; charset=utf-8",
+			s: 200,
+		},
+		{
+			h: "application/text; charset=utf-8",
+			s: 415,
+		},
+	}
+
+	for _, c := range tc {
+		res, err := http.Post(ts.URL, c.h, bytes.NewBufferString(`{"jsonrpc": "2.0", "method": "arith.pi", "id": 2 }`))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if res.StatusCode != c.s {
+			t.Errorf("Input: %s\n got %d expected %d", c.h, res.StatusCode, c.s)
+		}
+	}
+}
+
 func TestServer_ServeHTTP(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(rpc.ServeHTTP))
 	defer ts.Close()


### PR DESCRIPTION
Now content type checked on beginning with application/json because some libs may add additional info after that, like encoding