### PR TITLE
Make middleware functions run in right order;

### DIFF
--- a/server.go
+++ b/server.go
@@ -223,8 +223,8 @@ func (s Server) processRequest(ctx context.Context, req Request) Response {
 
 	// set middleware to func
 	f := InvokeFunc(s.services[namespace].Invoke)
-	for _, m := range s.middleware {
-		f = m(f)
+	for i := len(s.middleware)-1; i >= 0; i-- {
+		f = s.middleware[i](f)
 	}
 
 	// invoke func with middleware

--- a/testdata/printer.go
+++ b/testdata/printer.go
@@ -22,7 +22,7 @@ func (PrintService) PrintRequired(s string) string {
 func (PrintService) PrintOptional(s *string) string {
 	if s == nil {
 		return "string is empty"
-	} 
-	
-	return *s	
+	}
+
+	return *s
 }


### PR DESCRIPTION
Middleware should run in order in which they were registered. So now middleware functions wrapping in reverse order to do so.