### PR TITLE
 Avoid self-linked infinite recursion

### DIFF
--- a/parser/struct.go
+++ b/parser/struct.go
@@ -88,8 +88,11 @@ func (s *Struct) parse(pi *PackageInfo) error {
 				pi.Structs[internalS.Name] = internalS
 			}
 
-			if err := internalS.parse(pi); err != nil {
-				return err
+			// avoid self-linked infinite recursion
+			if internalS.Name != s.Name {
+				if err := internalS.parse(pi); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -194,7 +197,11 @@ func definitions(smdType SMDType, structs map[string]*Struct) []string {
 		for _, p := range s.Properties {
 			if p.SMDType.Ref != "" {
 				result = append(result, p.SMDType.Ref)
-				result = append(result, definitions(p.SMDType, structs)...)
+
+				// avoid self-linked infinite recursion
+				if smdType.Ref != p.SMDType.Ref {
+					result = append(result, definitions(p.SMDType, structs)...)
+				}
 			}
 		}
 	}

--- a/testdata/catalogue.go
+++ b/testdata/catalogue.go
@@ -9,7 +9,6 @@ type Group struct {
 	Title    string   `json:"title"`
 	Nodes    []Group  `json:"nodes"`
 	Groups   []Group  `json:"group"`
-	Child    Group    `json:"child"`
 	ChildOpt *Group   `json:"child"`
 	Sub      SubGroup `json:"sub"`
 }

--- a/testdata/catalogue.go
+++ b/testdata/catalogue.go
@@ -5,8 +5,19 @@ import (
 )
 
 type Group struct {
+	Id       int      `json:"id"`
+	Title    string   `json:"title"`
+	Nodes    []Group  `json:"nodes"`
+	Groups   []Group  `json:"group"`
+	Child    Group    `json:"child"`
+	ChildOpt *Group   `json:"child"`
+	Sub      SubGroup `json:"sub"`
+}
+
+type SubGroup struct {
 	Id    int    `json:"id"`
 	Title string `json:"title"`
+	//Nodes []Group `json:"nodes"` TODO still causes infinite recursion
 }
 
 type Campaign struct {

--- a/testdata/catalogue.go
+++ b/testdata/catalogue.go
@@ -1,0 +1,27 @@
+package testdata
+
+import (
+	"github.com/semrush/zenrpc"
+)
+
+type Group struct {
+	Id    int    `json:"id"`
+	Title string `json:"title"`
+}
+
+type Campaign struct {
+	Id     int     `json:"id"`
+	Groups []Group `json:"group"`
+}
+
+type CatalogueService struct{ zenrpc.Service }
+
+func (s CatalogueService) First(groups []Group) (bool, error) {
+	return true, nil
+}
+
+func (s CatalogueService) Second(campaigns []Campaign) (bool, error) {
+	return true, nil
+}
+
+//go:generate zenrpc

--- a/testdata/testdata_zenrpc.go
+++ b/testdata/testdata_zenrpc.go
@@ -468,6 +468,48 @@ func (CatalogueService) SMD() smd.ServiceInfo {
 										Description: ``,
 										Type:        smd.String,
 									},
+									"nodes": {
+										Description: ``,
+										Type:        smd.Array,
+										Items: map[string]string{
+											"$ref": "#/definitions/Group",
+										},
+									},
+									"group": {
+										Description: ``,
+										Type:        smd.Array,
+										Items: map[string]string{
+											"$ref": "#/definitions/Group",
+										},
+									},
+									"child": {
+										Description: ``,
+										Ref:         "#/definitions/Group",
+										Type:        smd.Object,
+									},
+									"child": {
+										Description: ``,
+										Ref:         "#/definitions/Group",
+										Type:        smd.Object,
+									},
+									"sub": {
+										Description: ``,
+										Ref:         "#/definitions/SubGroup",
+										Type:        smd.Object,
+									},
+								},
+							},
+							"SubGroup": {
+								Type: "object",
+								Properties: map[string]smd.Property{
+									"id": {
+										Description: ``,
+										Type:        smd.Integer,
+									},
+									"title": {
+										Description: ``,
+										Type:        smd.String,
+									},
 								},
 							},
 						},
@@ -508,6 +550,48 @@ func (CatalogueService) SMD() smd.ServiceInfo {
 								},
 							},
 							"Group": {
+								Type: "object",
+								Properties: map[string]smd.Property{
+									"id": {
+										Description: ``,
+										Type:        smd.Integer,
+									},
+									"title": {
+										Description: ``,
+										Type:        smd.String,
+									},
+									"nodes": {
+										Description: ``,
+										Type:        smd.Array,
+										Items: map[string]string{
+											"$ref": "#/definitions/Group",
+										},
+									},
+									"group": {
+										Description: ``,
+										Type:        smd.Array,
+										Items: map[string]string{
+											"$ref": "#/definitions/Group",
+										},
+									},
+									"child": {
+										Description: ``,
+										Ref:         "#/definitions/Group",
+										Type:        smd.Object,
+									},
+									"child": {
+										Description: ``,
+										Ref:         "#/definitions/Group",
+										Type:        smd.Object,
+									},
+									"sub": {
+										Description: ``,
+										Ref:         "#/definitions/SubGroup",
+										Type:        smd.Object,
+									},
+								},
+							},
+							"SubGroup": {
 								Type: "object",
 								Properties: map[string]smd.Property{
 									"id": {

--- a/testdata/testdata_zenrpc.go
+++ b/testdata/testdata_zenrpc.go
@@ -487,11 +487,6 @@ func (CatalogueService) SMD() smd.ServiceInfo {
 										Ref:         "#/definitions/Group",
 										Type:        smd.Object,
 									},
-									"child": {
-										Description: ``,
-										Ref:         "#/definitions/Group",
-										Type:        smd.Object,
-									},
 									"sub": {
 										Description: ``,
 										Ref:         "#/definitions/SubGroup",
@@ -573,11 +568,6 @@ func (CatalogueService) SMD() smd.ServiceInfo {
 										Items: map[string]string{
 											"$ref": "#/definitions/Group",
 										},
-									},
-									"child": {
-										Description: ``,
-										Ref:         "#/definitions/Group",
-										Type:        smd.Object,
 									},
 									"child": {
 										Description: ``,

--- a/testdata/testdata_zenrpc.go
+++ b/testdata/testdata_zenrpc.go
@@ -13,9 +13,10 @@ import (
 )
 
 var RPC = struct {
-	ArithService struct{ Sum, Positive, DoSomething, DoSomethingWithPoint, Multiply, CheckError, CheckZenRPCError, Divide, Pow, Pi, SumArray string }
-	PhoneBook    struct{ Get, ValidateSearch, ById, Delete, Remove, Save string }
-	PrintService struct{ PrintRequiredDefault, PrintOptionalWithDefault, PrintRequired, PrintOptional string }
+	ArithService     struct{ Sum, Positive, DoSomething, DoSomethingWithPoint, Multiply, CheckError, CheckZenRPCError, Divide, Pow, Pi, SumArray string }
+	CatalogueService struct{ First, Second string }
+	PhoneBook        struct{ Get, ValidateSearch, ById, Delete, Remove, Save string }
+	PrintService     struct{ PrintRequiredDefault, PrintOptionalWithDefault, PrintRequired, PrintOptional string }
 }{
 	ArithService: struct{ Sum, Positive, DoSomething, DoSomethingWithPoint, Multiply, CheckError, CheckZenRPCError, Divide, Pow, Pi, SumArray string }{
 		Sum:                  "sum",
@@ -29,6 +30,10 @@ var RPC = struct {
 		Pow:                  "pow",
 		Pi:                   "pi",
 		SumArray:             "sumarray",
+	},
+	CatalogueService: struct{ First, Second string }{
+		First:  "first",
+		Second: "second",
 	},
 	PhoneBook: struct{ Get, ValidateSearch, ById, Delete, Remove, Save string }{
 		Get:            "get",
@@ -428,6 +433,149 @@ func (s ArithService) Invoke(ctx context.Context, method string, params json.Raw
 		}
 
 		resp.Set(s.SumArray(args.Array))
+
+	default:
+		resp = zenrpc.NewResponseError(nil, zenrpc.MethodNotFound, "", nil)
+	}
+
+	return resp
+}
+
+func (CatalogueService) SMD() smd.ServiceInfo {
+	return smd.ServiceInfo{
+		Description: ``,
+		Methods: map[string]smd.Service{
+			"First": {
+				Description: ``,
+				Parameters: []smd.JSONSchema{
+					{
+						Name:        "groups",
+						Optional:    false,
+						Description: ``,
+						Type:        smd.Array,
+						Items: map[string]string{
+							"$ref": "#/definitions/Group",
+						},
+						Definitions: map[string]smd.Definition{
+							"Group": {
+								Type: "object",
+								Properties: map[string]smd.Property{
+									"id": {
+										Description: ``,
+										Type:        smd.Integer,
+									},
+									"title": {
+										Description: ``,
+										Type:        smd.String,
+									},
+								},
+							},
+						},
+					},
+				},
+				Returns: smd.JSONSchema{
+					Description: ``,
+					Optional:    false,
+					Type:        smd.Boolean,
+				},
+			},
+			"Second": {
+				Description: ``,
+				Parameters: []smd.JSONSchema{
+					{
+						Name:        "campaigns",
+						Optional:    false,
+						Description: ``,
+						Type:        smd.Array,
+						Items: map[string]string{
+							"$ref": "#/definitions/Campaign",
+						},
+						Definitions: map[string]smd.Definition{
+							"Campaign": {
+								Type: "object",
+								Properties: map[string]smd.Property{
+									"id": {
+										Description: ``,
+										Type:        smd.Integer,
+									},
+									"group": {
+										Description: ``,
+										Type:        smd.Array,
+										Items: map[string]string{
+											"$ref": "#/definitions/Group",
+										},
+									},
+								},
+							},
+							"Group": {
+								Type: "object",
+								Properties: map[string]smd.Property{
+									"id": {
+										Description: ``,
+										Type:        smd.Integer,
+									},
+									"title": {
+										Description: ``,
+										Type:        smd.String,
+									},
+								},
+							},
+						},
+					},
+				},
+				Returns: smd.JSONSchema{
+					Description: ``,
+					Optional:    false,
+					Type:        smd.Boolean,
+				},
+			},
+		},
+	}
+}
+
+// Invoke is as generated code from zenrpc cmd
+func (s CatalogueService) Invoke(ctx context.Context, method string, params json.RawMessage) zenrpc.Response {
+	resp := zenrpc.Response{}
+	var err error
+
+	switch method {
+	case RPC.CatalogueService.First:
+		var args = struct {
+			Groups []Group `json:"groups"`
+		}{}
+
+		if zenrpc.IsArray(params) {
+			if params, err = zenrpc.ConvertToObject([]string{"groups"}, params); err != nil {
+				return zenrpc.NewResponseError(nil, zenrpc.InvalidParams, "", err.Error())
+			}
+		}
+
+		if len(params) > 0 {
+			if err := json.Unmarshal(params, &args); err != nil {
+				return zenrpc.NewResponseError(nil, zenrpc.InvalidParams, "", err.Error())
+			}
+		}
+
+		resp.Set(s.First(args.Groups))
+
+	case RPC.CatalogueService.Second:
+		var args = struct {
+			Campaigns []Campaign `json:"campaigns"`
+		}{}
+
+		if zenrpc.IsArray(params) {
+			if params, err = zenrpc.ConvertToObject([]string{"campaigns"}, params); err != nil {
+				return zenrpc.NewResponseError(nil, zenrpc.InvalidParams, "", err.Error())
+			}
+		}
+
+		if len(params) > 0 {
+			if err := json.Unmarshal(params, &args); err != nil {
+				return zenrpc.NewResponseError(nil, zenrpc.InvalidParams, "", err.Error())
+			}
+		}
+
+		resp.Set(s.Second(args.Campaigns))
 
 	default:
 		resp = zenrpc.NewResponseError(nil, zenrpc.MethodNotFound, "", nil)


### PR DESCRIPTION
These changes allow avoiding infinite recursion for simple self-linked structures, e.g.

```go
type Group struct {
	Id       int      `json:"id"`
	Title    string   `json:"title"`
	Nodes    []Group  `json:"nodes"`
	Groups   []Group  `json:"group"`
	Child    Group    `json:"child"`
	ChildOpt *Group   `json:"child"`
	Sub      SubGroup `json:"sub"`
}
```

Nevertheless, the problem with infinite recursion still not fixed.