### PR TITLE
Fix CORS & docs, expose s.process()

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -107,7 +107,7 @@ func (s Server) ServeWS(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		data, err := json.Marshal(s.process(newRequestContext(r.Context(), r), message))
+		data, err := s.Do(newRequestContext(r.Context(), r), message)
 		if err != nil {
 			s.printf("marshal json response failed with err=%v", err)
 			c.WriteControl(websocket.CloseInternalServerErr, nil, time.Time{})

--- a/server.go
+++ b/server.go
@@ -130,7 +130,7 @@ func (s *Server) SetLogger(printer Printer) {
 
 // process process JSON-RPC 2.0 message, invokes correct method for namespace and returns JSON-RPC 2.0 Response.
 func (s *Server) process(ctx context.Context, message json.RawMessage) interface{} {
-	requests := []Request{}
+	var requests []Request
 	// parsing batch requests
 	batch := IsArray(message)
 
@@ -247,6 +247,11 @@ func (s Server) processRequest(ctx context.Context, req Request) Response {
 	return resp
 }
 
+// Do process JSON-RPC 2.0 request, invokes correct method for namespace and returns JSON-RPC 2.0 Response or marshaller error.
+func (s Server) Do(ctx context.Context, req []byte) ([]byte, error) {
+	return json.Marshal(s.process(ctx, req))
+}
+
 func (s Server) printf(format string, v ...interface{}) {
 	if s.logger != nil {
 		s.logger.Printf(format, v...)
@@ -300,7 +305,7 @@ func IsArray(message json.RawMessage) bool {
 func ConvertToObject(keys []string, params json.RawMessage) (json.RawMessage, error) {
 	paramCount := len(keys)
 
-	rawParams := []json.RawMessage{}
+	var rawParams []json.RawMessage
 	if err := json.Unmarshal(params, &rawParams); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch introduces the new method `Do(ctx, request) (resp, err)` for zenrpc Server.
We need this method for custom handlers implementation: eg. websockets or messaging systems.

Bugsfixes:
* CORS
* Docs handler is updated to latest semrush/smdbox version.
