### PR TITLE
Add ability to change param name & fix default values with spaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/prometheus/client_golang v1.7.1
-	github.com/prometheus/common v0.10.0
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/thoas/go-funk v0.6.0
 	golang.org/x/tools v0.0.0-20200729173947-1c30660f9f89

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,0 +1,194 @@
+package parser
+
+import "testing"
+
+func Test_parseArgumentComment(t *testing.T) {
+	tests := []struct {
+		test             string
+		line             string
+		wantName         string
+		wantAlias        string
+		wantHasDefault   bool
+		wantDefaultValue string
+		wantDescription  string
+	}{
+		{
+			test:     "should parse only name",
+			line:     "var",
+			wantName: "var",
+		},
+		{
+			test:     "should parse only name with spaces",
+			line:     " var ",
+			wantName: "var",
+		},
+		{
+			test:      "should parse name with alias",
+			line:      "var(alias)",
+			wantName:  "var",
+			wantAlias: "alias",
+		},
+		{
+			test:      "should parse name with alias with spaces",
+			line:      "var ( alias )",
+			wantName:  "var",
+			wantAlias: "alias",
+		},
+		{
+			test:             "should parse name with alias and default",
+			line:             "var(alias)=default",
+			wantName:         "var",
+			wantAlias:        "alias",
+			wantHasDefault:   true,
+			wantDefaultValue: "default",
+		},
+		{
+			test:             "should parse name with alias and default with spaces",
+			line:             "var(alias) = default",
+			wantName:         "var",
+			wantAlias:        "alias",
+			wantHasDefault:   true,
+			wantDefaultValue: "default",
+		},
+		{
+			test:             "should parse name with alias and quoted default",
+			line:             "var(alias)=`default`",
+			wantName:         "var",
+			wantAlias:        "alias",
+			wantHasDefault:   true,
+			wantDefaultValue: "default",
+		},
+		{
+			test:             "should parse name with alias and quoted default with spaces",
+			line:             "var(alias)= `defa ult ` ",
+			wantName:         "var",
+			wantAlias:        "alias",
+			wantHasDefault:   true,
+			wantDefaultValue: "defa ult ",
+		},
+		{
+			test:             "should parse name with alias, quoted default with spaces and description",
+			line:             "var(alias)= `defa ult `     description  ",
+			wantName:         "var",
+			wantAlias:        "alias",
+			wantHasDefault:   true,
+			wantDefaultValue: "defa ult ",
+			wantDescription:  "description",
+		},
+		{
+			test:            "should parse name and description",
+			line:            "var description",
+			wantName:        "var",
+			wantHasDefault:  false,
+			wantDescription: "description",
+		},
+		{
+			test:             "should parse name and default",
+			line:             "var=default",
+			wantName:         "var",
+			wantHasDefault:   true,
+			wantDefaultValue: "default",
+		},
+		{
+			test:             "should parse name and default and description",
+			line:             "var=default",
+			wantName:         "var",
+			wantHasDefault:   true,
+			wantDefaultValue: "default",
+		},
+		{
+			test:             "should parse name and quoted default",
+			line:             "var=`default`",
+			wantName:         "var",
+			wantHasDefault:   true,
+			wantDefaultValue: "default",
+		},
+		{
+			test:             "should parse name and quoted default and description",
+			line:             "var=`default` description",
+			wantName:         "var",
+			wantHasDefault:   true,
+			wantDefaultValue: "default",
+			wantDescription:  "description",
+		},
+		{
+			test:            "should parse name and alias and description",
+			line:            "var(alias) description",
+			wantName:        "var",
+			wantAlias:       "alias",
+			wantDescription: "description",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.test, func(t *testing.T) {
+			gotName, gotAlias, gotHasDefault, gotDefaultValue, gotDescription := parseArgumentComment(tt.line)
+			if gotName != tt.wantName {
+				t.Errorf("parseArgumentComment() gotName = %v, want %v", gotName, tt.wantName)
+			}
+			if gotAlias != tt.wantAlias {
+				t.Errorf("parseArgumentComment() gotAlias = %v, want %v", gotAlias, tt.wantAlias)
+			}
+			if gotHasDefault != tt.wantHasDefault {
+				t.Errorf("parseArgumentComment() gotHasDefault = %v, want %v", gotHasDefault, tt.wantHasDefault)
+			}
+			if gotDefaultValue != tt.wantDefaultValue {
+				t.Errorf("parseArgumentComment() gotDefaultValue = %v, want %v", gotDefaultValue, tt.wantDefaultValue)
+			}
+			if gotDescription != tt.wantDescription {
+				t.Errorf("parseArgumentComment() gotDefaultValue = %v, want %v", gotDefaultValue, tt.wantDefaultValue)
+			}
+		})
+	}
+}
+
+func Test_parseCommentType(t *testing.T) {
+	tests := []struct {
+		test string
+		line string
+		want string
+	}{
+		{
+			test: "should detect return",
+			line: "return result",
+			want: "return",
+		},
+		{
+			test: "should detect return without description",
+			line: "return",
+			want: "return",
+		},
+		{
+			test: "should detect error",
+			line: "0 description",
+			want: "error",
+		},
+		{
+			test: "should detect error with negative code",
+			line: "-100 description",
+			want: "error",
+		},
+		{
+			test: "should detect error without description",
+			line: "-100",
+			want: "error",
+		},
+		{
+			test: "should detect argument",
+			line: "var(alias)",
+			want: "argument",
+		},
+		{
+			test: "should detect argument with numbers",
+			line: "var100=100 description",
+			want: "argument",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.test, func(t *testing.T) {
+			if got := parseCommentType(tt.line); got != tt.want {
+				t.Errorf("parseCommentType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/testdata/phonebook.go
+++ b/testdata/phonebook.go
@@ -162,3 +162,9 @@ func (pb *PhoneBook) Save(p Person, replace *bool) (id uint64, err *zenrpc.Error
 
 	return pb.id, nil
 }
+
+// Prints message
+//zenrpc:str(type)=`"hello world"`
+func (pb *PhoneBook) Echo(str string) string {
+	return str
+}


### PR DESCRIPTION
Hi!

Here's reworked comments parsing section. New features suggested:
- ability to change argument name with braces eg. `//zenrpc:param(alias)`
- ability to specify default value with spaces using ticks (\`) eg. //zenrpc:param=\`"test"\`

Made with some wired regexp magic as quickest way to implement this feature. Backward compatible. Tests included.